### PR TITLE
fix: dvo_benchmark required dependency of dynamic-reconfigure

### DIFF
--- a/dvo_benchmark/CMakeLists.txt
+++ b/dvo_benchmark/CMakeLists.txt
@@ -4,7 +4,7 @@ project(dvo_benchmark)
 
 LIST(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules")
 
-find_package(catkin REQUIRED COMPONENTS roscpp dvo_core dvo_ros dvo_slam cv_bridge)
+find_package(catkin REQUIRED COMPONENTS roscpp dvo_core dvo_ros dvo_slam cv_bridge dynamic_reconfigure)
 find_package(cmake_modules REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(G2O REQUIRED)

--- a/dvo_benchmark/cmake_modules/FindG2O.cmake
+++ b/dvo_benchmark/cmake_modules/FindG2O.cmake
@@ -9,6 +9,7 @@ FIND_PATH(G2O_INCLUDE_DIR g2o/core/base_vertex.h
   /opt/local/include
   /sw/local/include
   /sw/include
+  /opt/ros/kinetic/include # temp hack
   NO_DEFAULT_PATH
   )
 
@@ -41,7 +42,7 @@ MACRO(FIND_G2O_LIBRARY MYLIBRARY MYLIBRARYNAME)
     /sw/local/lib
     /sw/lib
     )
-  
+
   FIND_LIBRARY(${MYLIBRARY}
     NAMES "g2o_${MYLIBRARYNAME}"
     PATHS
@@ -64,14 +65,15 @@ MACRO(FIND_G2O_LIBRARY MYLIBRARY MYLIBRARYNAME)
     /opt/local/lib
     /sw/local/lib
     /sw/lib
+    /opt/ros/kinetic/lib/ # temp hack
     )
-  
+
   IF(NOT ${MYLIBRARY}_DEBUG)
     IF(MYLIBRARY)
       SET(${MYLIBRARY}_DEBUG ${MYLIBRARY})
     ENDIF(MYLIBRARY)
   ENDIF( NOT ${MYLIBRARY}_DEBUG)
-  
+
 ENDMACRO(FIND_G2O_LIBRARY LIBRARY LIBRARYNAME)
 
 # Find the core elements

--- a/dvo_benchmark/package.xml
+++ b/dvo_benchmark/package.xml
@@ -14,6 +14,8 @@
 
   <build_depend>cmake_modules</build_depend>
 
+  <build_depend>dynamic-reconfigure</build_depend>
+
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>roscpp</build_depend>
@@ -21,7 +23,7 @@
   <build_depend>dvo_core</build_depend>
   <build_depend>dvo_ros</build_depend>
   <build_depend>dvo_slam</build_depend>
-    
+
   <run_depend>libpcl-all</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>

--- a/dvo_slam/cmake_modules/FindG2O.cmake
+++ b/dvo_slam/cmake_modules/FindG2O.cmake
@@ -9,6 +9,7 @@ FIND_PATH(G2O_INCLUDE_DIR g2o/core/base_vertex.h
   /opt/local/include
   /sw/local/include
   /sw/include
+  /opt/ros/kinetic/include # temp hack
   NO_DEFAULT_PATH
   )
 
@@ -41,7 +42,7 @@ MACRO(FIND_G2O_LIBRARY MYLIBRARY MYLIBRARYNAME)
     /sw/local/lib
     /sw/lib
     )
-  
+
   FIND_LIBRARY(${MYLIBRARY}
     NAMES "g2o_${MYLIBRARYNAME}"
     PATHS
@@ -64,14 +65,15 @@ MACRO(FIND_G2O_LIBRARY MYLIBRARY MYLIBRARYNAME)
     /opt/local/lib
     /sw/local/lib
     /sw/lib
+    /opt/ros/kinetic/lib/ # temp hack
     )
-  
+
   IF(NOT ${MYLIBRARY}_DEBUG)
     IF(MYLIBRARY)
       SET(${MYLIBRARY}_DEBUG ${MYLIBRARY})
     ENDIF(MYLIBRARY)
   ENDIF( NOT ${MYLIBRARY}_DEBUG)
-  
+
 ENDMACRO(FIND_G2O_LIBRARY LIBRARY LIBRARYNAME)
 
 # Find the core elements


### PR DESCRIPTION
On Ubuntu 16.04/ ROS Kinetic

`dvo_benchmark` subpackage depends on dynamic-reconfigure.
